### PR TITLE
Fix parameter order when calling construct_identity_relationship

### DIFF
--- a/multicred/manager.py
+++ b/multicred/manager.py
@@ -78,7 +78,7 @@ def do_link(args: argparse.Namespace, iolayer: Storage):
         aws_secret_access_key=response['Credentials']['SecretAccessKey'],
         aws_session_token=response['Credentials']['SessionToken'])
     iolayer.import_credentials(creds)
-    iolayer.construct_identity_relationship(parent_creds, creds, args.role_arn)
+    iolayer.construct_identity_relationship(creds, parent_creds, args.role_arn)
 def main():
     parser = build_parser()
     args = parser.parse_args()


### PR DESCRIPTION
manager.py called the function with the cred parameters swapped, so it created the wrong linkage and would likely trigger a unique constraint violation.

Addresses #32