### PR TITLE
Make IdentityHandle hashable

### DIFF
--- a/multicred/dbstorage.py
+++ b/multicred/dbstorage.py
@@ -23,6 +23,12 @@ class DBStorageIdentityHandle:
     @property
     def name(self) -> str:
         return self.data.name
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, IdentityHandle):
+            return False
+        return self.arn == other.arn
+    def __hash__(self) -> int:
+        return hash(self.arn)
 
 class DBStorage:
     engine: Engine

--- a/multicred/interfaces.py
+++ b/multicred/interfaces.py
@@ -1,6 +1,7 @@
-from typing import Protocol, Tuple
+from typing import Protocol, Tuple, runtime_checkable
 from . import credentials
 
+@runtime_checkable
 class IdentityHandle(Protocol):
     @property
     def account_id(self) -> int:
@@ -13,6 +14,10 @@ class IdentityHandle(Protocol):
         ...
     @property
     def name(self) -> str:
+        ...
+    def __eq__(self, other: object) -> bool:
+        ...
+    def __hash__(self) -> int:
         ...
 
 class Resolver(Protocol):


### PR DESCRIPTION
Add hashability to the IdentityHandle protocol and the DBStorageIdentityHandle class. The implementation could be moved to the IdentityHandle class, but that would require changing it from a protocol to a base class that is inherited by all storage implementations