### PR TITLE
Make AwsIdentity implement IdentityHandle

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ from pytest import fixture
 import boto3
 from moto import mock_aws
 
-from multicred.credentials  import Credentials, AwsRoleIdentity, AwsUserIdentity
+from multicred.credentials  import CredentialType, Credentials, AwsRoleIdentity, AwsUserIdentity
 from multicred.dbstorage import DBStorage
 from multicred.resolver import StorageBasedResolver
 from multicred.interfaces import Storage, Resolver
@@ -23,6 +23,23 @@ def user_identity():
     return AwsUserIdentity(
         aws_identity='arn:aws:iam::123456789012:user/test_user',
         aws_userid='AIDEXAMPLE')
+
+@dataclass(frozen=True)
+class TestIdentityHandle:
+    arn: str = 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    account_id: int = 123456789012
+    cred_type: CredentialType = CredentialType.ROLE
+    name: str = 'test_role'
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return other.__eq__(self)
+        return self.arn == other.arn
+    def __hash__(self) -> int:
+        return hash(self.arn)
+
+@fixture
+def test_identity_handle():
+    return TestIdentityHandle()
 
 @dataclass
 class CredentialsWrapper:

--- a/multicred/base_objects.py
+++ b/multicred/base_objects.py
@@ -1,0 +1,28 @@
+from typing import Protocol, runtime_checkable
+from enum import Enum
+
+class CredentialType(Enum):
+    """Enum to represent the type of AWS credentials."""
+    USER = 'user'
+    ROLE = 'role'
+    ASSUMED_ROLE = 'role'
+    UNKNOWN = 'unknown'
+
+@runtime_checkable
+class IdentityHandle(Protocol):
+    @property
+    def account_id(self) -> int:
+        ...
+    @property
+    def arn(self) -> str:
+        ...
+    @property
+    def cred_type(self) -> CredentialType:
+        ...
+    @property
+    def name(self) -> str:
+        ...
+    def __eq__(self, other: object) -> bool:
+        ...
+    def __hash__(self) -> int:
+        ...

--- a/multicred/credentials.py
+++ b/multicred/credentials.py
@@ -3,11 +3,10 @@ from typing import TYPE_CHECKING
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from configparser import ConfigParser
-from enum import Enum
 import botocore.exceptions
 from boto3 import session
 
-from .interfaces import IdentityHandle
+from .base_objects import IdentityHandle, CredentialType
 
 if TYPE_CHECKING:
     from mypy_boto3_sts.type_defs import GetCallerIdentityResponseTypeDef
@@ -30,12 +29,6 @@ class WrongIdentityTypeError(MultiCredError, TypeError):
 class BadIdentityError(MultiCredError, ValueError):
     pass
 
-class CredentialType(Enum):
-    """Enum to represent the type of AWS credentials."""
-    USER = 'user'
-    ROLE = 'role'
-    ASSUMED_ROLE = 'role'
-    UNKNOWN = 'unknown'
 
 @dataclass(frozen=True, eq=False)
 class AwsIdentity:

--- a/multicred/dbstorage.py
+++ b/multicred/dbstorage.py
@@ -67,21 +67,9 @@ class DBStorage:
         account, _ = self.get_one_or_create(
             session, dbschema.AwsAccountStorage, account_id=identity.aws_account_id)
         assert isinstance(account, dbschema.AwsAccountStorage)
-        if identity.cred_type == credentials.CredentialType.ROLE:
-            assert isinstance(identity, credentials.AwsRoleIdentity)
-            name = identity.aws_role_name
-        elif identity.cred_type == credentials.CredentialType.USER:
-            assert isinstance(identity, credentials.AwsUserIdentity)
-            name = identity.aws_user_name
-        elif identity.cred_type == credentials.CredentialType.UNKNOWN:
-            if not force:
-                raise ValueError('Credential is invalid and not indexable')
-            name = identity.aws_account_id
-        else:
-            raise ValueError('Unknown cred_type')
         stored_id, _ = self.get_one_or_create(
             session, dbschema.AwsIdentityStorage, aws_account=account,
-            cred_type=identity.cred_type.value, name=name,
+            cred_type=identity.cred_type.value, name=identity.name,
             create_method_kwargs={'arn': identity.aws_identity, 'userid': identity.aws_userid})
         credential = dbschema.AwsCredentialStorage(
             aws_identity=stored_id, aws_access_key_id=creds.aws_access_key_id,

--- a/multicred/interfaces.py
+++ b/multicred/interfaces.py
@@ -1,24 +1,6 @@
-from typing import Protocol, Tuple, runtime_checkable
+from typing import Protocol, Tuple
+from .base_objects import IdentityHandle
 from . import credentials
-
-@runtime_checkable
-class IdentityHandle(Protocol):
-    @property
-    def account_id(self) -> int:
-        ...
-    @property
-    def arn(self) -> str:
-        ...
-    @property
-    def cred_type(self) -> credentials.CredentialType:
-        ...
-    @property
-    def name(self) -> str:
-        ...
-    def __eq__(self, other: object) -> bool:
-        ...
-    def __hash__(self) -> int:
-        ...
 
 class Resolver(Protocol):
     def get_credentials_by_arn(self, arn: str) -> credentials.Credentials | None:

--- a/tests/test_dbstorage.py
+++ b/tests/test_dbstorage.py
@@ -2,7 +2,6 @@ from pytest import raises
 
 from sqlalchemy.exc import NoResultFound
 from multicred.dbschema import AwsAccountStorage, AwsIdentityStorage, AwsCredentialStorage
-from multicred.credentials import AwsRoleIdentity
 
 def test_empty_storage(empty_storage):
     with empty_storage.session() as session:
@@ -44,10 +43,9 @@ def test_find_parent_identity(derived_creds_storage):
     target_role_creds = derived_creds_storage.role_creds.test_object
     target_role_identity = target_role_creds.aws_identity
     assert target_role_identity.cred_type.value == 'role'
-    assert isinstance(target_role_identity, AwsRoleIdentity)
 
     target_stored_id = derived_creds_storage.test_object.get_identity_by_account_and_role_name(
-        target_role_identity.aws_account_id, target_role_identity.aws_role_name)
+        target_role_identity.aws_account_id, target_role_identity.name)
     assert target_stored_id is not None
     stored_id, role_arn = derived_creds_storage.test_object.get_parent_identity(
         target_stored_id)
@@ -59,10 +57,9 @@ def test_find_parent_identity_none(role_creds_storage):
     target_role_creds = role_creds_storage.credentials.test_object
     target_role_identity = target_role_creds.aws_identity
     assert target_role_identity.cred_type.value == 'role'
-    assert isinstance(target_role_identity, AwsRoleIdentity)
 
     target_stored_id = role_creds_storage.test_object.get_identity_by_account_and_role_name(
-        target_role_identity.aws_account_id, target_role_identity.aws_role_name)
+        target_role_identity.aws_account_id, target_role_identity.name)
     assert target_stored_id is not None
     stored_id, role_arn = role_creds_storage.test_object.get_parent_identity(
         target_stored_id)
@@ -73,10 +70,9 @@ def test_remove_parent_identity(derived_creds_storage):
     target_role_creds = derived_creds_storage.role_creds.test_object
     target_role_identity = target_role_creds.aws_identity
     assert target_role_identity.cred_type.value == 'role'
-    assert isinstance(target_role_identity, AwsRoleIdentity)
 
     target_stored_id = derived_creds_storage.test_object.get_identity_by_account_and_role_name(
-        target_role_identity.aws_account_id, target_role_identity.aws_role_name)
+        target_role_identity.aws_account_id, target_role_identity.name)
     assert target_stored_id is not None
     stored_id, role_arn = derived_creds_storage.test_object.get_parent_identity(
         target_stored_id)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,3 +1,4 @@
+from multicred.base_objects import IdentityHandle, CredentialType
 
 def test_aws_role_identity(role_identity):
     assert role_identity.aws_identity == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
@@ -6,6 +7,17 @@ def test_aws_role_identity(role_identity):
     assert role_identity.cred_type.value == 'role'
     assert role_identity.aws_account_id == '123456789012'
     assert role_identity.aws_role_name == 'test_role'
+
+
+def testaws_identity_protocol(role_identity, test_identity_handle):
+    assert isinstance(role_identity, IdentityHandle)
+    assert role_identity.account_id == 123456789012
+    assert role_identity.arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    assert role_identity.cred_type == CredentialType.ROLE
+    assert role_identity.name == 'test_role'
+    assert role_identity == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    assert hash(role_identity) == hash('arn:aws:sts::123456789012:assumed-role/test_role/test_session')
+    assert role_identity == test_identity_handle
 
 def test_aws_role_identity_repr(role_identity):
     assert repr(role_identity) == "AwsRoleIdentity(aws_userid='AROAEXAMPLE', " \


### PR DESCRIPTION
Implement the IdentityHandle protocol for AwsIdentity.
elimintate some identity type specific attribute accesses in favor of AwsIdentity.name
