### PR TITLE
Fix DB Storage ID handle

### DIFF
--- a/multicred/dbstorage.py
+++ b/multicred/dbstorage.py
@@ -14,7 +14,8 @@ class DBStorageIdentityHandle:
         self.data = data
     @property
     def account_id(self) -> int:
-        return self.data.aws_account_id
+        account : dbschema.AwsAccountStorage = self.data.aws_account
+        return int(account.account_id)
     @property
     def arn(self) -> str:
         return self.data.arn

--- a/tests/test_dbstorage.py
+++ b/tests/test_dbstorage.py
@@ -184,23 +184,35 @@ def test_list_identities_role(role_creds_storage):
     identities = list(role_creds_storage.test_object.list_identities())
     assert len(identities) == 1
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    assert identities[0].account_id == 123456789012
+    assert identities[0].name == 'test_role'
 
 def test_list_identities_user(user_creds_storage):
     identities = list(user_creds_storage.test_object.list_identities())
     assert len(identities) == 1
     assert identities[0].arn == 'arn:aws:iam::123456789012:user/test_user'
+    assert identities[0].account_id == 123456789012
+    assert identities[0].name == 'test_user'
 
 def test_list_identities_multiple(multiple_creds_storage):
     identities = list(multiple_creds_storage.test_object.list_identities())
     assert len(identities) == 2
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    assert identities[0].account_id == 123456789012
+    assert identities[0].name == 'test_role'
     assert identities[1].arn == 'arn:aws:iam::123456789012:user/test_user'
+    assert identities[1].account_id == 123456789012
+    assert identities[1].name == 'test_user'
 
 def test_list_identities_derived(derived_creds_storage):
     identities = list(derived_creds_storage.test_object.list_identities())
     assert len(identities) == 2
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    assert identities[0].account_id == 123456789012
+    assert identities[0].name == 'test_role'
     assert identities[1].arn == 'arn:aws:iam::123456789012:user/test_user'
+    assert identities[1].account_id == 123456789012
+    assert identities[1].name == 'test_user'
 
 def test_list_identity_credentials_empty(empty_storage):
     identities = list(empty_storage.list_identities())


### PR DESCRIPTION
Instead of returning the rowid of the account object, return the actual
AWS account id.