### PR TITLE
AWS account id should be a str

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,10 +26,18 @@ def user_identity():
 
 @dataclass(frozen=True)
 class TestIdentityHandle:
-    arn: str = 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    account_id: int = 123456789012
-    cred_type: CredentialType = CredentialType.ROLE
-    name: str = 'test_role'
+    @property
+    def account_id(self) -> str:
+        return '123456789012'
+    @property
+    def arn(self) -> str:
+        return 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    @property
+    def cred_type(self) -> CredentialType:
+        return CredentialType.ROLE
+    @property
+    def name(self) -> str:
+        return 'test_role'
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return other.__eq__(self)

--- a/multicred/base_objects.py
+++ b/multicred/base_objects.py
@@ -11,7 +11,7 @@ class CredentialType(Enum):
 @runtime_checkable
 class IdentityHandle(Protocol):
     @property
-    def account_id(self) -> int:
+    def account_id(self) -> str:
         ...
     @property
     def arn(self) -> str:

--- a/multicred/credentials.py
+++ b/multicred/credentials.py
@@ -60,8 +60,8 @@ class AwsIdentity:
         return self.aws_identity
 
     @property
-    def account_id(self) -> int:
-        return int(self.aws_account_id)
+    def account_id(self) -> str:
+        return self.aws_account_id
 
     @property
     def name(self) -> str:

--- a/multicred/dbstorage.py
+++ b/multicred/dbstorage.py
@@ -13,9 +13,9 @@ class DBStorageIdentityHandle:
     def __init__(self, data: dbschema.AwsIdentityStorage):
         self.data = data
     @property
-    def account_id(self) -> int:
+    def account_id(self) -> str:
         account : dbschema.AwsAccountStorage = self.data.aws_account
-        return int(account.account_id)
+        return account.account_id
     @property
     def arn(self) -> str:
         return self.data.arn

--- a/tests/test_dbstorage.py
+++ b/tests/test_dbstorage.py
@@ -184,34 +184,34 @@ def test_list_identities_role(role_creds_storage):
     identities = list(role_creds_storage.test_object.list_identities())
     assert len(identities) == 1
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    assert identities[0].account_id == 123456789012
+    assert identities[0].account_id == '123456789012'
     assert identities[0].name == 'test_role'
 
 def test_list_identities_user(user_creds_storage):
     identities = list(user_creds_storage.test_object.list_identities())
     assert len(identities) == 1
     assert identities[0].arn == 'arn:aws:iam::123456789012:user/test_user'
-    assert identities[0].account_id == 123456789012
+    assert identities[0].account_id == '123456789012'
     assert identities[0].name == 'test_user'
 
 def test_list_identities_multiple(multiple_creds_storage):
     identities = list(multiple_creds_storage.test_object.list_identities())
     assert len(identities) == 2
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    assert identities[0].account_id == 123456789012
+    assert identities[0].account_id == '123456789012'
     assert identities[0].name == 'test_role'
     assert identities[1].arn == 'arn:aws:iam::123456789012:user/test_user'
-    assert identities[1].account_id == 123456789012
+    assert identities[1].account_id == '123456789012'
     assert identities[1].name == 'test_user'
 
 def test_list_identities_derived(derived_creds_storage):
     identities = list(derived_creds_storage.test_object.list_identities())
     assert len(identities) == 2
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    assert identities[0].account_id == 123456789012
+    assert identities[0].account_id == '123456789012'
     assert identities[0].name == 'test_role'
     assert identities[1].arn == 'arn:aws:iam::123456789012:user/test_user'
-    assert identities[1].account_id == 123456789012
+    assert identities[1].account_id == '123456789012'
     assert identities[1].name == 'test_user'
 
 def test_list_identity_credentials_empty(empty_storage):

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -11,7 +11,7 @@ def test_aws_role_identity(role_identity):
 
 def testaws_identity_protocol(role_identity, test_identity_handle):
     assert isinstance(role_identity, IdentityHandle)
-    assert role_identity.account_id == 123456789012
+    assert role_identity.account_id == '123456789012'
     assert role_identity.arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
     assert role_identity.cred_type == CredentialType.ROLE
     assert role_identity.name == 'test_role'

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -17,6 +17,7 @@ def testaws_identity_protocol(role_identity, test_identity_handle):
     assert role_identity.name == 'test_role'
     assert role_identity == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
     assert hash(role_identity) == hash('arn:aws:sts::123456789012:assumed-role/test_role/test_session')
+    assert isinstance(test_identity_handle, IdentityHandle)
     assert role_identity == test_identity_handle
 
 def test_aws_role_identity_repr(role_identity):


### PR DESCRIPTION
Update all interfaces (mostly IdentityHandle and its implementation)
to treat AWS account ids as a string instead of an integer.