### PR TITLE
Fix credential helper output

### DIFF
--- a/multicred/credhelper.py
+++ b/multicred/credhelper.py
@@ -37,6 +37,7 @@ def main():
         print('No credentials found', file=sys.stderr)
         sys.exit(1)
     value = {
+        'Version': 1,
         'AccessKeyId': creds.aws_access_key_id,
         'SecretAccessKey': creds.aws_secret_access_key
     }


### PR DESCRIPTION
The credential helper protocol in boto/awscli requires a version field. multicred-credhelper should include it.