### PR TITLE
Import fixes

### DIFF
--- a/multicred/dbstorage.py
+++ b/multicred/dbstorage.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import NoResultFound, IntegrityError, MultipleResultsFound
 
 from . import dbschema
 from . import credentials
-from .base_objects import MultiCredStorageError, MultiCredLinkError
+from .base_objects import MultiCredStorageError, MultiCredLinkError, MultiCredBadRequest
 from .interfaces import IdentityHandle, Statistics, CredentialInfo
 
 class DBStorageError(MultiCredStorageError):
@@ -87,6 +87,8 @@ class DBStorage:
         return alt_id.data
 
     def import_credentials(self, creds: credentials.Credentials, force=False):
+        if not creds.is_valid:
+            raise MultiCredBadRequest('Invalid credentials cannot be imported')
         session = self.session()
         identity = creds.aws_identity
         try:

--- a/multicred/importer.py
+++ b/multicred/importer.py
@@ -20,6 +20,9 @@ def do_import(filename: str, iolayer: Storage, profile: str):
         textfile = get_textstream(rawfile)
         creds = credentials.Credentials.from_shared_credentials_file(
             textfile, profile_name=profile)
+    if not creds.is_valid:
+        print('Credentials are not active, cannot import', file=sys.stderr)
+        sys.exit(1)
     iolayer.import_credentials(creds)
 
 DB_PATH = 'sqlite:///' + os.path.expanduser('~/.aws/multicred.db')

--- a/multicred/importer.py
+++ b/multicred/importer.py
@@ -7,6 +7,7 @@ import chardet
 from . import get_storage
 from . import credentials
 from .interfaces import Storage
+from .base_objects import MultiCredError
 
 def get_textstream(file: io.BufferedReader) -> io.TextIOWrapper:
     '''Convert a binary file to a text stream'''
@@ -16,14 +17,28 @@ def get_textstream(file: io.BufferedReader) -> io.TextIOWrapper:
 
 def do_import(filename: str, iolayer: Storage, profile: str):
     '''Import credentials from a file'''
-    with open(filename, 'rb') as rawfile:
-        textfile = get_textstream(rawfile)
-        creds = credentials.Credentials.from_shared_credentials_file(
-            textfile, profile_name=profile)
+    try:
+        with open(filename, 'rb') as rawfile:
+            textfile = get_textstream(rawfile)
+            creds = credentials.Credentials.from_shared_credentials_file(
+                textfile, profile_name=profile)
+    except FileNotFoundError:
+        print(f'File {filename} not found', file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f'Error reading file: {e}', file=sys.stderr)
+        sys.exit(1)
+    except credentials.MissingCredentialsError as e:
+        print(f'Error reading credentials: {e}', file=sys.stderr)
+        sys.exit(1)
     if not creds.is_valid:
         print('Credentials are not active, cannot import', file=sys.stderr)
         sys.exit(1)
-    iolayer.import_credentials(creds)
+    try:
+        iolayer.import_credentials(creds)
+    except MultiCredError as e:
+        print(f'Error importing credentials: {e}', file=sys.stderr)
+        sys.exit(1)
 
 DB_PATH = 'sqlite:///' + os.path.expanduser('~/.aws/multicred.db')
 def main():


### PR DESCRIPTION
Don't allow invalid credentials to be imported, since we may not know
their identity, and cannot index them. 

Improve error handling in multicred-import (that is, print better messages when exceptions occur)