### PR TITLE
Change identity key

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,7 @@ def user_identity():
 @dataclass(frozen=True)
 class TestIdentityHandle:
     @property
-    def account_id(self) -> str:
+    def aws_account_id(self) -> str:
         return '123456789012'
     @property
     def arn(self) -> str:

--- a/multicred/base_objects.py
+++ b/multicred/base_objects.py
@@ -12,7 +12,7 @@ class CredentialType(Enum):
 @runtime_checkable
 class IdentityHandle(Protocol):
     @property
-    def account_id(self) -> str:
+    def aws_account_id(self) -> str:
         ...
     @property
     def arn(self) -> str:
@@ -31,7 +31,7 @@ class IdentityHandle(Protocol):
 @dataclass(frozen=True)
 class IdentityKey:
     cred_type: CredentialType
-    account_id: str
+    aws_account_id: str
     name: str
 
 class MultiCredError(Exception):

--- a/multicred/base_objects.py
+++ b/multicred/base_objects.py
@@ -1,5 +1,6 @@
 from typing import Protocol, runtime_checkable
 from enum import Enum
+from dataclasses import dataclass
 
 class CredentialType(Enum):
     """Enum to represent the type of AWS credentials."""
@@ -26,6 +27,12 @@ class IdentityHandle(Protocol):
         ...
     def __hash__(self) -> int:
         ...
+
+@dataclass(frozen=True)
+class IdentityKey:
+    cred_type: CredentialType
+    account_id: str
+    name: str
 
 class MultiCredError(Exception):
     """Base class for all exceptions in multicred"""

--- a/multicred/credentials.py
+++ b/multicred/credentials.py
@@ -55,10 +55,6 @@ class AwsIdentity:
         return self.aws_identity
 
     @property
-    def account_id(self) -> str:
-        return self.aws_account_id
-
-    @property
     def name(self) -> str:
         if len(self._resource_components) == 2 or (
                 len(self._resource_components) == 3 and self.cred_type == CredentialType.ROLE

--- a/multicred/credentials.py
+++ b/multicred/credentials.py
@@ -6,7 +6,9 @@ from configparser import ConfigParser
 import botocore.exceptions
 from boto3 import session
 
-from .base_objects import IdentityHandle, CredentialType, MultiCredError
+from .base_objects import IdentityKey, IdentityHandle, CredentialType, \
+    MultiCredError
+from .utils import parse_principal
 
 if TYPE_CHECKING:
     from mypy_boto3_sts.type_defs import GetCallerIdentityResponseTypeDef
@@ -27,26 +29,25 @@ class BadIdentityError(MultiCredError, ValueError):
 
 @dataclass(frozen=True, eq=False)
 class AwsIdentity:
-    aws_identity: str = field(repr=False)
+    aws_identity: str = field(repr=False, compare=False)
     aws_userid : str
     _arn_components: list[str] = field(init=False, repr=False, compare=False)
     _resource_components: list[str] = field(
         init=False, repr=False, compare=False)
-    aws_account_id: str = field(init=False, compare=False)
-    cred_type: CredentialType = field(init=False, compare=False)
+    _key: IdentityKey = field(init=False)
     cred_path: str = field(init=False, compare=False)
 
     def __post_init__(self):
         if not self.aws_identity.startswith('arn:aws:'):
             raise BadIdentityError('Invalid AWS identity')
+        object.__setattr__(self, '_key',
+                           parse_principal(self.aws_identity))
         elements = self.aws_identity.split(':')
         if len(elements) != 6:
             raise BadIdentityError('Invalid AWS identity')
         object.__setattr__(self, '_arn_components',  elements[4:])
         object.__setattr__(self, '_resource_components',
                            elements[5].split('/'))
-        object.__setattr__(self, 'aws_account_id', elements[4])
-        object.__setattr__(self, 'cred_type', CredentialType[self._resource_components[0].upper().replace('-', '_')])
         object.__setattr__(self, 'cred_path',
                            '/'.join(self._resource_components[1:]))
 
@@ -55,25 +56,40 @@ class AwsIdentity:
         return self.aws_identity
 
     @property
+    def aws_account_id(self) -> str:
+        return self._key.aws_account_id
+
+    @property
+    def cred_type(self) -> CredentialType:
+        return self._key.cred_type
+
+    @property
     def name(self) -> str:
-        if len(self._resource_components) == 2 or (
-                len(self._resource_components) == 3 and self.cred_type == CredentialType.ROLE
-        ):
-            return self._resource_components[1]
-        raise WrongIdentityTypeError('This identity does not have a simple name')
+        return self._key.name
+
+    @property
+    def key(self) -> IdentityKey:
+        return self._key
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, AwsIdentity):
-            return self.aws_identity == other.aws_identity and \
+            return self._key == other._key and \
                 self.aws_userid == other.aws_userid
-        if isinstance(other, str):
-            return self.aws_identity == other
+        arn = None
         if isinstance(other, IdentityHandle):
-            return self.aws_identity == other.arn
-        return False
+            arn = other.arn
+        elif isinstance(other, str):
+            arn = other
+        if arn is None:
+            return False
+        try:
+            key = parse_principal(arn)
+        except ValueError:
+            return False
+        return self._key == key
 
     def __hash__(self) -> int:
-        return hash(self.aws_identity)
+        return hash(self._key)
 
 @dataclass(frozen=True, eq=False)
 class AwsRoleIdentity(AwsIdentity):

--- a/multicred/dbstorage.py
+++ b/multicred/dbstorage.py
@@ -20,7 +20,7 @@ class DBStorageIdentityHandle:
     def __init__(self, data: dbschema.AwsIdentityStorage):
         self.data = data
     @property
-    def account_id(self) -> str:
+    def aws_account_id(self) -> str:
         account : dbschema.AwsAccountStorage = self.data.aws_account
         return account.account_id
     @property

--- a/multicred/manager.py
+++ b/multicred/manager.py
@@ -107,7 +107,7 @@ def do_stats(iolayer: Storage):
 def do_list_ids(iolayer: Storage):
     for identity in iolayer.list_identities():
         print(f'ARN: {identity.arn}')
-        print(f'Account: {identity.account_id}')
+        print(f'Account: {identity.aws_account_id}')
         print(f'Short Identifier: {identity.name}')
         print()
 

--- a/multicred/utils.py
+++ b/multicred/utils.py
@@ -1,0 +1,21 @@
+from .base_objects import CredentialType, IdentityKey
+
+def parse_principal(arn: str) -> IdentityKey:
+    """Parse an ARN and return an IdentityHandle object."""
+    if not arn.startswith('arn:aws:'):
+        raise ValueError('Invalid ARN')
+    elements = arn.split(':')
+    if len(elements) != 6:
+        raise ValueError('Invalid ARN')
+    resource = elements[5].split('/')
+    # maybe root also?
+    if resource[0] not in ['user', 'role', 'assumed-role', 'unknown']:
+        raise ValueError('Invalid principal ARN')
+    cred_type = CredentialType[resource[0].upper().replace('-', '_')]
+    account_id = elements[4]
+    if resource[0] == 'assumed-role':
+        # first resource is the role name, second is the session name
+        name = resource[1]
+    else:
+        name = resource[-1]
+    return IdentityKey(cred_type, account_id, name)

--- a/tests/test_dbstorage.py
+++ b/tests/test_dbstorage.py
@@ -33,7 +33,18 @@ def test_role_storage_get_key(role_creds_storage):
 def test_find_identity_by_arn(role_creds_storage):
     stored_id = role_creds_storage.test_object.get_identity_by_arn(
         'arn:aws:sts::123456789012:assumed-role/test_role/test_session')
+    assert stored_id
     assert stored_id.arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    assert stored_id == role_creds_storage.credentials.test_object.aws_identity
+    stored_id_2 = role_creds_storage.test_object.get_identity_by_arn(
+        'arn:aws:iam::123456789012:role/test_role')
+    assert stored_id_2
+    assert stored_id_2.aws_account_id == '123456789012'
+    assert stored_id_2.cred_type.value == 'role'
+    assert stored_id_2.name == 'test_role'
+    assert stored_id == stored_id_2
+    null_id = role_creds_storage.test_object.get_identity_by_arn('invalid_arn')
+    assert null_id is None
 
 def test_find_identity_by_account_and_role_name(role_creds_storage):
     stored_id = role_creds_storage.test_object.get_identity_by_account_and_role_name(

--- a/tests/test_dbstorage.py
+++ b/tests/test_dbstorage.py
@@ -185,34 +185,34 @@ def test_list_identities_role(role_creds_storage):
     identities = list(role_creds_storage.test_object.list_identities())
     assert len(identities) == 1
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    assert identities[0].account_id == '123456789012'
+    assert identities[0].aws_account_id == '123456789012'
     assert identities[0].name == 'test_role'
 
 def test_list_identities_user(user_creds_storage):
     identities = list(user_creds_storage.test_object.list_identities())
     assert len(identities) == 1
     assert identities[0].arn == 'arn:aws:iam::123456789012:user/test_user'
-    assert identities[0].account_id == '123456789012'
+    assert identities[0].aws_account_id == '123456789012'
     assert identities[0].name == 'test_user'
 
 def test_list_identities_multiple(multiple_creds_storage):
     identities = list(multiple_creds_storage.test_object.list_identities())
     assert len(identities) == 2
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    assert identities[0].account_id == '123456789012'
+    assert identities[0].aws_account_id == '123456789012'
     assert identities[0].name == 'test_role'
     assert identities[1].arn == 'arn:aws:iam::123456789012:user/test_user'
-    assert identities[1].account_id == '123456789012'
+    assert identities[1].aws_account_id == '123456789012'
     assert identities[1].name == 'test_user'
 
 def test_list_identities_derived(derived_creds_storage):
     identities = list(derived_creds_storage.test_object.list_identities())
     assert len(identities) == 2
     assert identities[0].arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    assert identities[0].account_id == '123456789012'
+    assert identities[0].aws_account_id == '123456789012'
     assert identities[0].name == 'test_role'
     assert identities[1].arn == 'arn:aws:iam::123456789012:user/test_user'
-    assert identities[1].account_id == '123456789012'
+    assert identities[1].aws_account_id == '123456789012'
     assert identities[1].name == 'test_user'
 
 def test_list_identity_credentials_empty(empty_storage):

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -16,6 +16,11 @@ def testaws_identity_protocol(role_identity, test_identity_handle):
     assert role_identity.cred_type == CredentialType.ROLE
     assert role_identity.name == 'test_role'
     assert role_identity == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
+    assert role_identity == 'arn:aws:iam::123456789012:role/test_role'
+    assert role_identity == 'arn:aws:iam::123456789012:role/with_path/test_role'
+    assert role_identity != 'arn:aws:iam::123456789012:user/test_role'
+    assert role_identity != 'arn:aws:iam::123456789012:role/test_role/test_session'
+    assert role_identity != 'invalid_arn'
     assert isinstance(test_identity_handle, IdentityHandle)
     assert role_identity == test_identity_handle
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -16,13 +16,13 @@ def testaws_identity_protocol(role_identity, test_identity_handle):
     assert role_identity.cred_type == CredentialType.ROLE
     assert role_identity.name == 'test_role'
     assert role_identity == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
-    assert hash(role_identity) == hash('arn:aws:sts::123456789012:assumed-role/test_role/test_session')
     assert isinstance(test_identity_handle, IdentityHandle)
     assert role_identity == test_identity_handle
 
 def test_aws_role_identity_repr(role_identity):
     assert repr(role_identity) == "AwsRoleIdentity(aws_userid='AROAEXAMPLE', " \
-            "aws_account_id='123456789012', cred_type=<CredentialType.ROLE: 'role'>, " \
+            "_key=IdentityKey(cred_type=<CredentialType.ROLE: 'role'>, "\
+            "aws_account_id='123456789012', name='test_role'), " \
             "cred_path='test_role/test_session', aws_role_name='test_role', " \
             "aws_role_session_name='test_session')"
 
@@ -36,6 +36,7 @@ def test_aws_user_identity(user_identity):
 
 def test_aws_user_identity_repr(user_identity):
     assert repr(user_identity) == "AwsUserIdentity(aws_userid='AIDEXAMPLE', " \
-            "aws_account_id='123456789012', cred_type=<CredentialType.USER: 'user'>, " \
+            "_key=IdentityKey(cred_type=<CredentialType.USER: 'user'>, "\
+            "aws_account_id='123456789012', name='test_user'), " \
             "cred_path='test_user', aws_user_name='test_user')"
     

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -11,7 +11,7 @@ def test_aws_role_identity(role_identity):
 
 def testaws_identity_protocol(role_identity, test_identity_handle):
     assert isinstance(role_identity, IdentityHandle)
-    assert role_identity.account_id == '123456789012'
+    assert role_identity.aws_account_id == '123456789012'
     assert role_identity.arn == 'arn:aws:sts::123456789012:assumed-role/test_role/test_session'
     assert role_identity.cred_type == CredentialType.ROLE
     assert role_identity.name == 'test_role'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,37 +6,37 @@ def test_parse_principal_role():
     arn = 'arn:aws:iam::123456789012:role/role-name'
     identity_key = parse_principal(arn)
     assert identity_key.cred_type == CredentialType.ROLE
-    assert identity_key.account_id == '123456789012'
+    assert identity_key.aws_account_id == '123456789012'
     assert identity_key.name == 'role-name'
 def test_parse_principal_role_withpath():
     arn = 'arn:aws:iam::123456789012:role/path/role-name'
     identity_key = parse_principal(arn)
     assert identity_key.cred_type == CredentialType.ROLE
-    assert identity_key.account_id == '123456789012'
+    assert identity_key.aws_account_id == '123456789012'
     assert identity_key.name == 'role-name'
 def test_parse_principal_user():
     arn = 'arn:aws:iam::123456789012:user/user-name'
     identity_key = parse_principal(arn)
     assert identity_key.cred_type == CredentialType.USER
-    assert identity_key.account_id == '123456789012'
+    assert identity_key.aws_account_id == '123456789012'
     assert identity_key.name == 'user-name'
 def test_parse_principal_assumed_role():
     arn = 'arn:aws:iam::123456789012:assumed-role/role-name/session-name'
     identity_key = parse_principal(arn)
     assert identity_key.cred_type == CredentialType.ROLE
-    assert identity_key.account_id == '123456789012'
+    assert identity_key.aws_account_id == '123456789012'
     assert identity_key.name == 'role-name'
 def test_parse_principal_unknown_named():
     arn = 'arn:aws:iam::123456789012:unknown/unknown-name'
     identity_key = parse_principal(arn)
     assert identity_key.cred_type == CredentialType.UNKNOWN
-    assert identity_key.account_id == '123456789012'
+    assert identity_key.aws_account_id == '123456789012'
     assert identity_key.name == 'unknown-name'
 def test_parse_principal_unknown_unnamed():
     arn = 'arn:aws:iam::123456789012:unknown'
     identity_key = parse_principal(arn)
     assert identity_key.cred_type == CredentialType.UNKNOWN
-    assert identity_key.account_id == '123456789012'
+    assert identity_key.aws_account_id == '123456789012'
     assert identity_key.name == 'unknown'
 def test_parse_principal_invalid_arn():
     arn = 'arn:aws:iam::123456789012:invalid'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+from pytest import raises
+from multicred.base_objects import CredentialType
+from multicred.utils import parse_principal
+
+def test_parse_principal_role():
+    arn = 'arn:aws:iam::123456789012:role/role-name'
+    identity_key = parse_principal(arn)
+    assert identity_key.cred_type == CredentialType.ROLE
+    assert identity_key.account_id == '123456789012'
+    assert identity_key.name == 'role-name'
+def test_parse_principal_role_withpath():
+    arn = 'arn:aws:iam::123456789012:role/path/role-name'
+    identity_key = parse_principal(arn)
+    assert identity_key.cred_type == CredentialType.ROLE
+    assert identity_key.account_id == '123456789012'
+    assert identity_key.name == 'role-name'
+def test_parse_principal_user():
+    arn = 'arn:aws:iam::123456789012:user/user-name'
+    identity_key = parse_principal(arn)
+    assert identity_key.cred_type == CredentialType.USER
+    assert identity_key.account_id == '123456789012'
+    assert identity_key.name == 'user-name'
+def test_parse_principal_assumed_role():
+    arn = 'arn:aws:iam::123456789012:assumed-role/role-name/session-name'
+    identity_key = parse_principal(arn)
+    assert identity_key.cred_type == CredentialType.ROLE
+    assert identity_key.account_id == '123456789012'
+    assert identity_key.name == 'role-name'
+def test_parse_principal_unknown_named():
+    arn = 'arn:aws:iam::123456789012:unknown/unknown-name'
+    identity_key = parse_principal(arn)
+    assert identity_key.cred_type == CredentialType.UNKNOWN
+    assert identity_key.account_id == '123456789012'
+    assert identity_key.name == 'unknown-name'
+def test_parse_principal_unknown_unnamed():
+    arn = 'arn:aws:iam::123456789012:unknown'
+    identity_key = parse_principal(arn)
+    assert identity_key.cred_type == CredentialType.UNKNOWN
+    assert identity_key.account_id == '123456789012'
+    assert identity_key.name == 'unknown'
+def test_parse_principal_invalid_arn():
+    arn = 'arn:aws:iam::123456789012:invalid'
+    with raises(ValueError):
+        parse_principal(arn)
+def test_parse_principal_invalid_resource():
+    arn = 'arn:aws:iam::123456789012:invalid/invalid-name'
+    with raises(ValueError):
+        parse_principal(arn)
+def test_parse_principal_root():
+    # root credentials are explicitly not supported
+    arn = 'arn:aws:iam::123456789012:root'
+    with raises(ValueError):
+        parse_principal(arn)


### PR DESCRIPTION
Instead of using ARN strings in identity comparisons and database lookups, always decompose the ARN to a tuple (account, type, name) and use that.

Fixes #61