### PR TITLE
Update requirements-dev based on dependabot

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ cffi==1.17.0
 chardet==5.2.0
 charset-normalizer==3.3.2
 colorama==0.4.6
-cryptography==42.0.7
+cryptography==43.0.1
 greenlet==3.1.1
 idna==3.8
 iniconfig==2.0.0
@@ -32,5 +32,5 @@ SQLAlchemy==2.0.34
 types-awscrt==0.20.9
 typing_extensions==4.12.2
 urllib3==2.2.3
-Werkzeug==3.0.4
+Werkzeug==3.0.6
 xmltodict==0.14.2


### PR DESCRIPTION
Move dev dependencies based on
GHSA-q34m-jh98-gwm2 (CVE-2024-49767)
GHSA-f9vj-2wh5-fj8j (CVE-2024-49766)
GHSA-h4gh-qq45-vh27

These dependencies are only used for tests/typing, and none should have any impact on the application