### PR TITLE
Add s3transfer to boto group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
         applies-to: version-updates
         patterns:
         - "boto*"
+        - "s3transfer"
         update-types:
         - "minor"
     ignore:


### PR DESCRIPTION
include s3transfer in the boto group, since the s3transfer 0.10 to 0.11 uodate must be coordinated with boto updates